### PR TITLE
Remove Apache PID on start

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -2,6 +2,8 @@
 
 chown -R apache:apache ${RAINLOOP_HOME}
 
+rm -f /run/apache2/httpd.pid
+
 sh -c "find . -type d -exec chmod 755 {} \;"
 sh -c "find . -type f -exec chmod 644 {} \;"
 


### PR DESCRIPTION
When you _kill_ the container and start it again it will complain that ```httpd``` is already running. Removing the PID on start fixes this.