### PR TITLE
Updated to version 1.11.0.203

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,14 @@
 FROM alpine:3.4
 MAINTAINER Niclas Mietz niclas@mietz.io
 
-ENV RAINLOOP_VERSION 1.10.5.192
+ENV RAINLOOP_VERSION 1.11.0.203
 
 ENV RAINLOOP_BUILD="/etc/rainloop" \
     RAINLOOP_HOME="/var/www/rainloop" \
-    RAINLOOP_CLONE_URL="https://github.com/RainLoop/rainloop-webmail.git" \
-    REQUIRED_PACKAGES="apache2 php5-apache2 php5-openssl php5-xml php5-json php5-iconv php5-curl php5-pdo_mysql php5-pdo_pgsql php5-pdo_sqlite php5-dom php5-zlib"
+    REQUIRED_PACKAGES="apache2 php5-apache2 php5-openssl php5-xml php5-json php5-iconv php5-curl php5-pdo_mysql php5-pdo_pgsql php5-pdo_sqlite php5-dom php5-zlib unzip curl"
 
 RUN \
+  apk update && \
   apk add --no-cache $REQUIRED_PACKAGES && \
   mkdir -p /run/apache2 && \
   rm -fr /var/cache/apk/* && \
@@ -17,16 +17,15 @@ RUN \
 
 RUN echo "@commuedge https://nl.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories && \
     echo "@testing https://nl.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories  && \
-    apk add -U git nodejs findutils && \
-    npm install gulp -g && \
-    git clone -q -b v${RAINLOOP_VERSION} --depth 1  ${RAINLOOP_CLONE_URL} ${RAINLOOP_BUILD}  && \
-    cd ${RAINLOOP_BUILD} && \
-    npm install && \
-    gulp rainloop:start && \
-    mv build/dist/releases/webmail/${RAINLOOP_VERSION}/src ${RAINLOOP_HOME} && \
-    npm uninstall -g gulp && \
-    apk del --purge git nodejs && \
-    rm -fr ${RAINLOOP_BUILD} /root/.npm /tmp/* /var/cache/apk/*
+    mkdir -p ${RAINLOOP_HOME} && \
+    cd ${RAINLOOP_HOME} && \
+    curl -L -O https://github.com/RainLoop/rainloop-webmail/releases/download/v${RAINLOOP_VERSION}/rainloop-community-${RAINLOOP_VERSION}.zip && \
+    unzip *.zip && \
+    rm -f *.zip && \
+    find . -type d -exec chmod 755 {} \; && \
+    find . -type f -exec chmod 644 {} \; && \ 
+    chown -R apache: *
+ 
 
 ADD httpd.conf /etc/apache2/httpd.conf
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,8 @@ version: '2'
 services:
   rainloop:
     container_name: "rainloop"
-    image: solidnerd/rainloop:1.10.5.192
+#    image: solidnerd/rainloop:1.10.5.192
+    build: .
     volumes:
       - ./data:/var/www/rainloop/data
     ports:


### PR DESCRIPTION
Updated to version 1.11.0.203, refactoring to use Rainloop GitHub release ZIP file. This way the image is built much faster and with fewer issues.